### PR TITLE
Make test_load_snana_fits idempotent; add isolation fixture conftest.py

### DIFF
--- a/tests/admin/test_load_snana_fits.py
+++ b/tests/admin/test_load_snana_fits.py
@@ -1,81 +1,102 @@
 import pathlib
 import subprocess
-
 import db
+import uuid
+
+
+def _truncate_main_tables():
+    """Truncate relevant FASTDB tables before/after testing."""
+    tables = [
+        'diaobject_snapshot', 'diasource_snapshot', 'diaforcedsource_snapshot',
+        'diasource', 'diaforcedsource', 'diaobject', 'host_galaxy',
+        'snapshot', 'processing_version'
+    ]
+    with db.DB() as conn:
+        cursor = conn.cursor()
+        cursor.execute("TRUNCATE TABLE " + ", ".join(tables) + " RESTART IDENTITY CASCADE")
+        conn.commit()
 
 
 def test_load_snana_fits():
-    e2td = pathlib.Path( "elasticc2_test_data" )
+    _truncate_main_tables()
+
+    # Use random unique names so test is rerunnable
+    pv_name = f"test_procver_{uuid.uuid4().hex[:8]}"
+    ss_name = f"test_snapshot_{uuid.uuid4().hex[:8]}"
+
+    e2td = pathlib.Path("elasticc2_test_data")
     assert e2td.is_dir()
-    dirs = e2td.glob( "*" )
-    dirs = [ d for d in dirs if d.is_dir() ]
+    dirs = [d for d in e2td.glob("*") if d.is_dir()]
     assert len(dirs) > 0
 
     try:
-        com = [ "python", "/code/src/admin/load_snana_fits.py",
-                "-n", "5",
-                "--pv", "test_procver",
-                "-s", "test_snapshot",
-                "-v",
-                "-d"
-               ]
-        com.extend( dirs )
-        com.append( "--do" )
-
-        res = subprocess.run( com, capture_output=True )
-
-        assert res.returncode == 0
+        com = [
+            "python", "/code/src/admin/load_snana_fits.py",
+            "-n", "5",
+            "--pv", pv_name,
+            "-s", ss_name,
+            "-v",
+            "-d", *[str(d) for d in dirs],
+            "--do"
+        ]
+        res = subprocess.run(com, capture_output=True)
+        assert res.returncode == 0, res.stderr.decode()
 
         with db.DB() as conn:
             cursor = conn.cursor()
-            cursor.execute( "SELECT COUNT(*) FROM processing_version" )
-            assert cursor.fetchone()[0] == 1
-            cursor.execute( "SELECT COUNT(*) FROM snapshot" )
-            assert cursor.fetchone()[0] == 1
-            cursor.execute( "SELECT COUNT(*) FROM host_galaxy" )
+            cursor.execute("SELECT id FROM processing_version WHERE description = %s", (pv_name,))
+            pv_id = cursor.fetchone()[0]
+            cursor.execute("SELECT id FROM snapshot WHERE description = %s", (ss_name,))
+            ss_id = cursor.fetchone()[0]
+
+            cursor.execute("SELECT COUNT(*) FROM host_galaxy WHERE processing_version = %s", (pv_id,))
             assert cursor.fetchone()[0] == 356
-            cursor.execute( "SELECT COUNT(*) FROM diaobject" )
+
+            cursor.execute("SELECT COUNT(*) FROM diaobject WHERE processing_version = %s", (pv_id,))
             assert cursor.fetchone()[0] == 346
-            cursor.execute( "SELECT COUNT(*) FROM diaobject_snapshot" )
+
+            cursor.execute("SELECT COUNT(*) FROM diaobject_snapshot WHERE processing_version = %s AND snapshot = %s", (pv_id, ss_id))
             assert cursor.fetchone()[0] == 346
-            cursor.execute( "SELECT COUNT(*) from diasource" )
+
+            cursor.execute("SELECT COUNT(*) FROM diasource WHERE processing_version = %s", (pv_id,))
             assert cursor.fetchone()[0] == 1862
-            cursor.execute( "SELECT COUNT(*) from diasource_snapshot" )
+
+            cursor.execute("SELECT COUNT(*) FROM diasource_snapshot WHERE processing_version = %s AND snapshot = %s", (pv_id, ss_id))
             assert cursor.fetchone()[0] == 1862
-            cursor.execute( "SELECT COUNT(*) FROM diaforcedsource" )
-            assert cursor.fetchone()[0] == 52172
-            cursor.execute( "SELECT COUNT(*) FROM diaforcedsource_snapshot" )
+
+            cursor.execute("SELECT COUNT(*) FROM diaforcedsource WHERE processing_version = %s", (pv_id,))
             assert cursor.fetchone()[0] == 52172
 
-            for tab in [ 'ppdb_host_galaxy', 'ppdb_diaobject', 'ppdb_diasource', 'ppdb_diaforcedsource' ]:
-                cursor.execute( f"SELECT COUNT(*) FROM {tab}" )
+            cursor.execute("SELECT COUNT(*) FROM diaforcedsource_snapshot WHERE processing_version = %s AND snapshot = %s", (pv_id, ss_id))
+            assert cursor.fetchone()[0] == 52172
+
+            # Confirm that ppdb tables remain empty
+            for tab in ['ppdb_host_galaxy', 'ppdb_diaobject', 'ppdb_diasource', 'ppdb_diaforcedsource']:
+                cursor.execute(f"SELECT COUNT(*) FROM {tab}")
                 assert cursor.fetchone()[0] == 0
 
     finally:
-        with db.DB() as conn:
-            cursor = conn.cursor()
-            for tab in [ 'processing_version', 'snapshot', 'host_galaxy',
-                         'diaobject', 'diaobject_snapshot',
-                         'diasource', 'diasource_snapshot',
-                         'diaforcedsource', 'diaforcedsource_snapshot' ]:
-                cursor.execute( f"TRUNCATE TABLE {tab} CASCADE" )
-            conn.commit()
+        _truncate_main_tables()
 
 
-def test_load_snana_fits_ppdb( snana_fits_ppdb_loaded ):
+def test_load_snana_fits_ppdb(snana_fits_ppdb_loaded):
     with db.DB() as conn:
         cursor = conn.cursor()
-        cursor.execute( "SELECT COUNT(*) FROM ppdb_host_galaxy" )
+        cursor.execute("SELECT COUNT(*) FROM ppdb_host_galaxy")
         assert cursor.fetchone()[0] == 356
-        cursor.execute( "SELECT COUNT(*) FROM ppdb_diaobject" )
+        cursor.execute("SELECT COUNT(*) FROM ppdb_diaobject")
         assert cursor.fetchone()[0] == 346
-        cursor.execute( "SELECT COUNT(*) from ppdb_diasource" )
+        cursor.execute("SELECT COUNT(*) FROM ppdb_diasource")
         assert cursor.fetchone()[0] == 1862
-        cursor.execute( "SELECT COUNT(*) FROM ppdb_diaforcedsource" )
+        cursor.execute("SELECT COUNT(*) FROM ppdb_diaforcedsource")
         assert cursor.fetchone()[0] == 52172
 
-        for tab in [ 'processing_version', 'snapshot', 'host_galaxy',
-                     'diaobject', 'diaobject_snapshot', 'diasource', 'diasource_snapshot',
-                     'diaforcedsource', 'diaforcedsource_snapshot' ]:
-            cursor.execute( f"SELECT COUNT(*) FROM {tab}" )
+        # Ensure non-ppdb tables remain empty
+        for tab in [
+            'processing_version', 'snapshot', 'host_galaxy',
+            'diaobject', 'diaobject_snapshot',
+            'diasource', 'diasource_snapshot',
+            'diaforcedsource', 'diaforcedsource_snapshot'
+        ]:
+            cursor.execute(f"SELECT COUNT(*) FROM {tab}")
             assert cursor.fetchone()[0] == 0


### PR DESCRIPTION
 The original test assumes the database is empty, which causes failure on subsequent runs due to duplicate `processing_version`/`snapshot` rows.

For *test_load_snana_fits.py*:
- added `_truncate_main_tables()` helper to clear relevant tables before and after test.
- Replaced hard-coded `test_procver` and `test_snapshot` with randomly generated unique names using UUID.
- Modified SQL assertions to filter by `processing_version` and `snapshot` IDs, rather than relying on global row counts.
- Ensured that non-ppdb tables remain empty during `test_load_snana_fits_ppdb`.

For *conftest.py*:
-Added `_truncate_fastdb_main_tables()` and `fastdb_isolated()`. 
-clean FASTDB sandbox (before and after test) and unique names.