### PR TITLE
Make it so both x86_64 and aarch64 architectures work.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,8 +17,6 @@ services:
     image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-kafka-test-${ARCH:-x86_64}:${DOCKER_VERSION:-latest}
     build:
       context: ./docker/kafka
-      args:
-        ARCH: ${ARCH:-x86_64}
     healthcheck:
       test: netcat -w 1 localhost 2181 || exit 1
       interval: 5s
@@ -33,8 +31,6 @@ services:
     image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-kafka-test-${ARCH:-x86_64}:${DOCKER_VERSION:-latest}
     build:
       context: ./docker/kafka
-      args:
-        ARCH: ${ARCH:-x86_64}
     healthcheck:
       test: netcat -w 1 localhost 9092 || exit 1
       interval: 5s
@@ -47,8 +43,6 @@ services:
     build:
       context: ./docker/postgres
       target: postgres
-      args:
-        ARCH: ${ARCH:-x86_64}
     volumes:
       - type: volume
         source: postgres_data
@@ -67,8 +61,6 @@ services:
     image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-mongodb-${ARCH:-x86_64}:${DOCKER_VERSION:-latest}
     build:
       context: ./docker/mongodb
-      args:
-        ARCH: ${ARCH:-x86_64}
     environment:
       - MONGODB_HOST=mongodb
       - MONGODB_DBNAME=brokeralert
@@ -97,8 +89,6 @@ services:
     build:
       context: ./docker/webserver
       target: shell
-      args:
-        ARCH: ${ARCH:-x86_64}
     user: ${USERID:-0}:${GROUPID:-0}
     volumes:
       - type: bind
@@ -120,8 +110,6 @@ services:
     build:
       context: ./docker/query_runner
       target: queryrunner
-      args:
-        ARCH: ${ARCH:-x86_64}
     user: ${USERID:-0}:${GROUPID:-0}
     volumes:
       - type: bind
@@ -153,8 +141,6 @@ services:
     build:
       context: ./docker/webserver
       target: webserver
-      args:
-        ARCH: ${ARCH:-x86_64}
     environment:
       - MONGODB_HOST=mongodb
       - MONGODB_DBNAME=brokeralert
@@ -211,8 +197,6 @@ services:
     build:
       context: ./docker/webserver
       target: shell
-      args:
-        ARCH: ${ARCH:-x86_64}
     environment:
       - MONGODB_HOST=mongodb
       - MONGODB_DBNAME=brokeralert
@@ -264,8 +248,6 @@ services:
     build:
       context: ./docker/webserver
       target: shell
-      args:
-        ARCH: ${ARCH:-x86_64}
     environment:
       - MONGODB_HOST=mongodb
       - MONGODB_DBNAME=brokeralert

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@
 
 services:
   kafka-zookeeper:
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-kafka-test-${ARCH:-x86_64}:${DOCKER_VERSION:-latest}
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-kafka-test:${DOCKER_VERSION:-latest}
     build:
       context: ./docker/kafka
     healthcheck:
@@ -17,7 +17,7 @@ services:
     depends_on:
        kafka-zookeeper:
          condition: service_healthy
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-kafka-test-${ARCH:-x86_64}:${DOCKER_VERSION:-latest}
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-kafka-test:${DOCKER_VERSION:-latest}
     build:
       context: ./docker/kafka
     healthcheck:
@@ -28,7 +28,7 @@ services:
     entrypoint: [ "bin/kafka-server-start.sh", "config/server.properties" ]
 
   postgres:
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-postgres-${ARCH:-x86_64}:${DOCKER_VERSION:-latest}
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-postgres:${DOCKER_VERSION:-latest}
     build:
       context: ./docker/postgres
       target: postgres
@@ -47,7 +47,7 @@ services:
       retries: 10
 
   mongodb:
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-mongodb-${ARCH:-x86_64}:${DOCKER_VERSION:-latest}
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-mongodb:${DOCKER_VERSION:-latest}
     build:
       context: ./docker/mongodb
     environment:
@@ -74,7 +74,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell-${ARCH:-x86_64}:${DOCKER_VERSION:-latest}
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell:${DOCKER_VERSION:-latest}
     build:
       context: ./docker/webserver
       target: shell
@@ -95,7 +95,7 @@ services:
     depends_on:
       createdb:
         condition: service_completed_successfully
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-query-runner-${ARCH:-x86_64}:${DOCKER_VERSION:-latest}
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-query-runner:${DOCKER_VERSION:-latest}
     build:
       context: ./docker/query_runner
       target: queryrunner
@@ -126,7 +126,7 @@ services:
         condition: service_started
       queryrunner:
         condition: service_started
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-webap-${ARCH:-x86_64}:${DOCKER_VERSION:-latest}
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-webap:${DOCKER_VERSION:-latest}
     build:
       context: ./docker/webserver
       target: webserver
@@ -182,7 +182,7 @@ services:
         condition: service_healthy
       createdb:
         condition: service_completed_successfully
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell-${ARCH:-x86_64}:${DOCKER_VERSION:-latest}
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell:${DOCKER_VERSION:-latest}
     build:
       context: ./docker/webserver
       target: shell
@@ -233,7 +233,7 @@ services:
         condition: service_healthy
       mongodb:
         condition: service_healthy
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell-${ARCH:-x86_64}:${DOCKER_VERSION:-latest}
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell:${DOCKER_VERSION:-latest}
     build:
       context: ./docker/webserver
       target: shell

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,16 +1,5 @@
 # This is a docker compose environment to bring up a dev/test fastdb
 # environment.
-#
-# To use it, you need to make sure to build it for the architecture of
-# your system.  If you're on an x86_64 system, it should work as is.  If
-# you're on an ARM system, then you need to do something different.
-#
-# In general, to build the images, run
-#
-#   ARCH=<architecture> docker compose build
-#
-# where <architecture> is one of "x86_64" or "aarch64".  (In the case of
-# x86_64, you can optionally omit the intial ARCH=...)
 
 services:
   kafka-zookeeper:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@
 #
 # In general, to build the images, run
 #
-#   ARCH=<architecture> docker compose build --build-arg ARCH=<architecture>
+#   ARCH=<architecture> docker compose build
 #
 # where <architecture> is one of "x86_64" or "aarch64".  (In the case of
 # x86_64, you can optionally omit the intial ARCH=...)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,12 +1,24 @@
 # This is a docker compose environment to bring up a dev/test fastdb
-# environment
+# environment.
+#
+# To use it, you need to make sure to build it for the architecture of
+# your system.  If you're on an x86_64 system, it should work as is.  If
+# you're on an ARM system, then you need to do something different.
+#
+# In general, to build the images, run
+#
+#   ARCH=<architecture> docker compose build --build-arg ARCH=<architecture>
+#
+# where <architecture> is one of "x86_64" or "aarch64".  (In the case of
+# x86_64, you can optionally omit the intial ARCH=...)
 
 services:
   kafka-zookeeper:
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-kafka-test:${DOCKER_VERSION:-latest}
-    platform: linux/amd64
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-kafka-test-${ARCH:-x86_64}:${DOCKER_VERSION:-latest}
     build:
       context: ./docker/kafka
+      args:
+        ARCH: ${ARCH:-x86_64}
     healthcheck:
       test: netcat -w 1 localhost 2181 || exit 1
       interval: 5s
@@ -18,10 +30,11 @@ services:
     depends_on:
        kafka-zookeeper:
          condition: service_healthy
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-kafka-test:${DOCKER_VERSION:-latest}
-    platform: linux/amd64
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-kafka-test-${ARCH:-x86_64}:${DOCKER_VERSION:-latest}
     build:
       context: ./docker/kafka
+      args:
+        ARCH: ${ARCH:-x86_64}
     healthcheck:
       test: netcat -w 1 localhost 9092 || exit 1
       interval: 5s
@@ -30,11 +43,12 @@ services:
     entrypoint: [ "bin/kafka-server-start.sh", "config/server.properties" ]
 
   postgres:
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-postgres:${DOCKER_VERSION:-latest}
-    platform: linux/amd64
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-postgres-${ARCH:-x86_64}:${DOCKER_VERSION:-latest}
     build:
       context: ./docker/postgres
       target: postgres
+      args:
+        ARCH: ${ARCH:-x86_64}
     volumes:
       - type: volume
         source: postgres_data
@@ -50,10 +64,11 @@ services:
       retries: 10
 
   mongodb:
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-mongodb:${DOCKER_VERSION:-latest}
-    platform: linux/amd64
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-mongodb-${ARCH:-x86_64}:${DOCKER_VERSION:-latest}
     build:
       context: ./docker/mongodb
+      args:
+        ARCH: ${ARCH:-x86_64}
     environment:
       - MONGODB_HOST=mongodb
       - MONGODB_DBNAME=brokeralert
@@ -78,11 +93,12 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell:${DOCKER_VERSION:-latest}
-    platform: linux/amd64
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell-${ARCH:-x86_64}:${DOCKER_VERSION:-latest}
     build:
       context: ./docker/webserver
       target: shell
+      args:
+        ARCH: ${ARCH:-x86_64}
     user: ${USERID:-0}:${GROUPID:-0}
     volumes:
       - type: bind
@@ -93,7 +109,6 @@ services:
 
   mailhog:
     image: mailhog/mailhog:latest
-    platform: linux/amd64
     ports:
       - "${MAILHOG_PORT:-8025}:8025"
 
@@ -101,11 +116,12 @@ services:
     depends_on:
       createdb:
         condition: service_completed_successfully
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-query-runner:${DOCKER_VERSION:-latest}
-    platform: linux/amd64
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-query-runner-${ARCH:-x86_64}:${DOCKER_VERSION:-latest}
     build:
       context: ./docker/query_runner
       target: queryrunner
+      args:
+        ARCH: ${ARCH:-x86_64}
     user: ${USERID:-0}:${GROUPID:-0}
     volumes:
       - type: bind
@@ -133,11 +149,12 @@ services:
         condition: service_started
       queryrunner:
         condition: service_started
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-webap:${DOCKER_VERSION:-latest}
-    platform: linux/amd64
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-webap-${ARCH:-x86_64}:${DOCKER_VERSION:-latest}
     build:
       context: ./docker/webserver
       target: webserver
+      args:
+        ARCH: ${ARCH:-x86_64}
     environment:
       - MONGODB_HOST=mongodb
       - MONGODB_DBNAME=brokeralert
@@ -190,11 +207,12 @@ services:
         condition: service_healthy
       createdb:
         condition: service_completed_successfully
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell:${DOCKER_VERSION:-latest}
-    platform: linux/amd64
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell-${ARCH:-x86_64}:${DOCKER_VERSION:-latest}
     build:
       context: ./docker/webserver
       target: shell
+      args:
+        ARCH: ${ARCH:-x86_64}
     environment:
       - MONGODB_HOST=mongodb
       - MONGODB_DBNAME=brokeralert
@@ -242,11 +260,12 @@ services:
         condition: service_healthy
       mongodb:
         condition: service_healthy
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell:${DOCKER_VERSION:-latest}
-    platform: linux/amd64
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell-${ARCH:-x86_64}:${DOCKER_VERSION:-latest}
     build:
       context: ./docker/webserver
       target: shell
+      args:
+        ARCH: ${ARCH:-x86_64}
     environment:
       - MONGODB_HOST=mongodb
       - MONGODB_DBNAME=brokeralert

--- a/docker/kafka/Dockerfile
+++ b/docker/kafka/Dockerfile
@@ -8,7 +8,7 @@ LABEL maintainenr="Rob Knop <raknop@lbl.gov>"
 SHELL ["/bin/bash", "-c"]
 RUN apt-get -y update \
    && apt-get -y upgrade \
-   && apt-get -y install openjdk-17-jre curl netcat-openbsd \
+   && apt-get -y install openjdk-17-jre curl netcat-openbsd ca-certificates \
    && apt-get clean \
    && rm -rf /var/lib/apt/lists/*
 

--- a/docker/kafka/Dockerfile
+++ b/docker/kafka/Dockerfile
@@ -1,7 +1,8 @@
 # This is the Dockerfile for the throwaway kafka server used in tests
 
-FROM rknop/devuan-daedalus-rknop
+ARG ARCH=x86_64
 
+FROM rknop/devuan-daedalus-rknop-$ARCH
 LABEL maintainenr="Rob Knop <raknop@lbl.gov>"
 
 SHELL ["/bin/bash", "-c"]

--- a/docker/kafka/Dockerfile
+++ b/docker/kafka/Dockerfile
@@ -1,8 +1,6 @@
 # This is the Dockerfile for the throwaway kafka server used in tests
 
-ARG ARCH=x86_64
-
-FROM rknop/devuan-daedalus-rknop-$ARCH
+FROM debian:bookworm-20250630
 LABEL maintainenr="Rob Knop <raknop@lbl.gov>"
 
 SHELL ["/bin/bash", "-c"]

--- a/docker/mongodb/Dockerfile
+++ b/docker/mongodb/Dockerfile
@@ -1,4 +1,6 @@
-FROM rknop/devuan-daedalus-rknop AS base
+ARG ARCH=x86-64
+
+FROM rknop/devuan-daedalus-rknop-$ARCH AS base
 LABEL maintainer="Rob Knop <raknop@lbl.gov>"
 
 SHELL ["/bin/bash", "-c"]

--- a/docker/mongodb/Dockerfile
+++ b/docker/mongodb/Dockerfile
@@ -35,9 +35,9 @@ RUN curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | \
    --dearmor
 
 RUN if [ "$ARCH" == "aarch64" ]; then \
-    echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg,arch=arm64 ] http://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list ; \
+    echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg arch=arm64 ] http://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list ; \
     else \
-    echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg,arch=amd64 ] http://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list ; \
+    echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg arch=amd64 ] http://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list ; \
     fi
 
 RUN apt-get update \

--- a/docker/mongodb/Dockerfile
+++ b/docker/mongodb/Dockerfile
@@ -1,7 +1,7 @@
-ARG ARCH=x86-64
+# FROM rknop/devuan-daedalus-rknop-$ARCH AS base
+# LABEL maintainer="Rob Knop <raknop@lbl.gov>"
 
-FROM rknop/devuan-daedalus-rknop-$ARCH AS base
-LABEL maintainer="Rob Knop <raknop@lbl.gov>"
+FROM mongo:8.0.11 AS BASE
 
 SHELL ["/bin/bash", "-c"]
 
@@ -15,7 +15,7 @@ WORKDIR /usr/src
 RUN apt-get update \
   && DEBIAN_FRONTEND="nointeractive" apt-get -y upgrade \
   && DEBIAN_FRONTEND="noninteractive" TZ="UTC" apt-get -y install -y --no-install-recommends \
-         ca-certificates gnupg curl sudo netcat-openbsd tmux locales \
+         ca-certificates sudo netcat-openbsd tmux locales \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -27,25 +27,6 @@ ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 
 ENV LESS=-XLRi
-
-# Install Mongo
-
-RUN curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | \
-   sudo gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg \
-   --dearmor
-
-RUN if [ "$ARCH" == "aarch64" ]; then \
-    echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg arch=arm64 ] http://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list ; \
-    else \
-    echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg arch=amd64 ] http://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list ; \
-    fi
-
-RUN apt-get update \
-  && DEBIAN_FRONTEND="noninteractive" TZ="UTC" apt-get -y install -y --no-install-recommends \
-          mongodb-org \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
-
 
 COPY mongod.conf /etc/mongod.conf
 RUN mkdir -p /data/db

--- a/docker/mongodb/Dockerfile
+++ b/docker/mongodb/Dockerfile
@@ -3,10 +3,9 @@ ARG ARCH=x86-64
 FROM rknop/devuan-daedalus-rknop-$ARCH AS base
 LABEL maintainer="Rob Knop <raknop@lbl.gov>"
 
-ENV ARCH=${ARCH}
-RUN if [ "$ARCH" = "aarch64" ]; then export ALTARCH=arm64 ; else ALTARCH=arm64 ; fi
-
 SHELL ["/bin/bash", "-c"]
+
+ENV ARCH=${ARCH}
 
 WORKDIR /usr/src
 
@@ -34,7 +33,11 @@ RUN curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | \
    sudo gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg \
    --dearmor
 
-RUN echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg,arch=$ALTARCH ] http://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
+RUN if [ "$ARCH" == "aarch64" ]; then \
+    echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg,arch=arm64 ] http://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list ; \
+    else \
+    echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg,arch=amd64 ] http://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list ; \
+    fi
 
 RUN apt-get update \
   && DEBIAN_FRONTEND="noninteractive" TZ="UTC" apt-get -y install -y --no-install-recommends \

--- a/docker/mongodb/Dockerfile
+++ b/docker/mongodb/Dockerfile
@@ -1,13 +1,6 @@
-# FROM rknop/devuan-daedalus-rknop-$ARCH AS base
-# LABEL maintainer="Rob Knop <raknop@lbl.gov>"
-
 FROM mongo:8.0.11 AS BASE
 
 SHELL ["/bin/bash", "-c"]
-
-ARG ARCH=x86-64
-ENV ARCH=$ARCH
-
 WORKDIR /usr/src
 
 # Base System

--- a/docker/mongodb/Dockerfile
+++ b/docker/mongodb/Dockerfile
@@ -5,7 +5,8 @@ LABEL maintainer="Rob Knop <raknop@lbl.gov>"
 
 SHELL ["/bin/bash", "-c"]
 
-ENV ARCH=${ARCH}
+ARG ARCH=x86-64
+ENV ARCH=$ARCH
 
 WORKDIR /usr/src
 

--- a/docker/mongodb/Dockerfile
+++ b/docker/mongodb/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /usr/src
 RUN apt-get update \
   && DEBIAN_FRONTEND="nointeractive" apt-get -y upgrade \
   && DEBIAN_FRONTEND="noninteractive" TZ="UTC" apt-get -y install -y --no-install-recommends \
-         gnupg curl sudo netcat-openbsd tmux locales \
+         ca-certificates gnupg curl sudo netcat-openbsd tmux locales \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/docker/mongodb/Dockerfile
+++ b/docker/mongodb/Dockerfile
@@ -3,6 +3,9 @@ ARG ARCH=x86-64
 FROM rknop/devuan-daedalus-rknop-$ARCH AS base
 LABEL maintainer="Rob Knop <raknop@lbl.gov>"
 
+ENV ARCH=${ARCH}
+RUN if [ "$ARCH" = "aarch64" ]; then export ALTARCH=arm64 ; else ALTARCH=arm64 ; fi
+
 SHELL ["/bin/bash", "-c"]
 
 WORKDIR /usr/src
@@ -31,7 +34,7 @@ RUN curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | \
    sudo gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg \
    --dearmor
 
-RUN echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] http://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg,arch=$ALTARCH ] http://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
 
 RUN apt-get update \
   && DEBIAN_FRONTEND="noninteractive" TZ="UTC" apt-get -y install -y --no-install-recommends \

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -5,7 +5,9 @@
 #   DOCKER_BUILDKIT=1 docker build --target postgres -t registry.nersc.gov/m1727/raknop/fastdb-postgres:rknop-dev .
 #
 
-FROM rknop/devuan-daedalus-rknop AS base
+ARG ARCH=x86_64
+
+FROM rknop/devuan-daedalus-rknop-$ARCH AS base
 LABEL maintainer="Rob Knop <raknop@lbl.gov>"
 
 SHELL ["/bin/bash", "-c"]
@@ -45,7 +47,7 @@ WORKDIR /build
 RUN apt-get update \
   && DEBIAN_FRONTEND="noninteractive" TZ="UTC" apt-get -y install -y --no-install-recommends \
       make git gcc libssl-dev libreadline-dev zlib1g-dev libzstd-dev liblz4-dev curl \
-      postgresql-server-dev-15
+      postgresql-server-dev-15 ca-certificates
 
 RUN git clone https://github.com/segasai/q3c.git
 RUN cd q3c \

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -5,9 +5,7 @@
 #   DOCKER_BUILDKIT=1 docker build --target postgres -t registry.nersc.gov/m1727/raknop/fastdb-postgres:rknop-dev .
 #
 
-ARG ARCH=x86_64
-
-FROM rknop/devuan-daedalus-rknop-$ARCH AS base
+FROM debian:bookworm-20250630 AS base
 LABEL maintainer="Rob Knop <raknop@lbl.gov>"
 
 SHELL ["/bin/bash", "-c"]

--- a/docker/query_runner/Dockerfile
+++ b/docker/query_runner/Dockerfile
@@ -4,9 +4,7 @@
 # Rob, use:
 # DOCKER_BUILDKIT=1 docker build --target queryrunner -t registry.nersc.gov/m1727/raknop/fastdb-query-runner:rknop-dev .
 
-ARG ARCH=x86_64
-
-FROM rknop/devuan-daedalus-rknop-$ARCH AS base
+FROM debian:bookworm-20250630 AS base
 LABEL maintainer="Rob Knop <rknop@pobox.com>"
 
 SHELL ["/bin/bash", "-c"]

--- a/docker/query_runner/Dockerfile
+++ b/docker/query_runner/Dockerfile
@@ -31,7 +31,7 @@ FROM base AS build
 RUN DEBIAN_FRONTEND="noninteractive" TZ="UTC" \
     apt-get update \
     && DEBIAN_FRONTEND="noninteractive" TZ="UTC" \
-    apt-get -y install -y python3-pip python3-venv git libpq-dev
+    apt-get -y install -y python3-pip python3-venv git libpq-dev ca-certificates
 
 RUN mkdir /venv
 RUN python3 -mvenv /venv

--- a/docker/query_runner/Dockerfile
+++ b/docker/query_runner/Dockerfile
@@ -4,7 +4,9 @@
 # Rob, use:
 # DOCKER_BUILDKIT=1 docker build --target queryrunner -t registry.nersc.gov/m1727/raknop/fastdb-query-runner:rknop-dev .
 
-FROM rknop/devuan-daedalus-rknop AS base
+ARG ARCH=x86_64
+
+FROM rknop/devuan-daedalus-rknop-$ARCH AS base
 LABEL maintainer="Rob Knop <rknop@pobox.com>"
 
 SHELL ["/bin/bash", "-c"]

--- a/docker/webserver/Dockerfile
+++ b/docker/webserver/Dockerfile
@@ -20,7 +20,7 @@ ENV TZ="UTC"
 RUN  apt-get update \
     && apt-get -y upgrade \
     && apt-get -y install -y \
-         python3 locales tmux netcat-openbsd gnupg curl elinks postgresql-client make rlwrap socat \
+         python3 locales tmux netcat-openbsd gnupg curl elinks postgresql-client make rlwrap socat ca-certificates \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/webserver/Dockerfile
+++ b/docker/webserver/Dockerfile
@@ -7,7 +7,9 @@
 #   DOCKER_BUILDKIT=1 docker build --target webserver -t registry.nersc.gov/m1727/raknop/fastdb-webap:rknop-dev .
 #   DOCKER_BUILDKIT=1 docker build --target shell -t registry.nersc.gov/m1727/raknop/fastdb-shell:rknop-dev .
 
-FROM rknop/devuan-daedalus-rknop AS base
+ARG ARCH=x86_64
+
+FROM rknop/devuan-daedalus-rknop-$ARCH AS base
 LABEL maintainer="Rob Knop <rknop@pobox.com>"
 
 SHELL ["/bin/bash", "-c"]

--- a/docker/webserver/Dockerfile
+++ b/docker/webserver/Dockerfile
@@ -7,9 +7,7 @@
 #   DOCKER_BUILDKIT=1 docker build --target webserver -t registry.nersc.gov/m1727/raknop/fastdb-webap:rknop-dev .
 #   DOCKER_BUILDKIT=1 docker build --target shell -t registry.nersc.gov/m1727/raknop/fastdb-shell:rknop-dev .
 
-ARG ARCH=x86_64
-
-FROM rknop/devuan-daedalus-rknop-$ARCH AS base
+FROM debian:bookworm-20250630 AS base
 LABEL maintainer="Rob Knop <rknop@pobox.com>"
 
 SHELL ["/bin/bash", "-c"]

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -65,26 +65,14 @@ Build and run the Docker services
 
 The file ``docker-compose.yaml`` in the top-level directory contains (almost) everything necessary to bring up a test FASTDB environment on your local machine.  You'll need to have some form of docker installed, with a new enough version of ``docker compose``.  Rob is able to get things to work with Docker 20.10.24 (run ``docker --version``) and docker compose 2.36.2 (run ``docker compose version``).  If you have older versions and something doesn't work, try upgrading.  You'll need to have the docker container runtime going; how that works depends on exactly which docker you install.  On a Linux, we rcommend `installing Docker Engline <https://docs.docker.com/engine/install/>`_.  On a Mac, you can also try that, but people have had success with `Docker Desktop <https://www.docker.com/products/docker-desktop>`_.
 
-First, you need to figure out your architecture.  If it's not ``x86_64`` or ``aarch64``, then you're system is not supported.  (Or, rather, it may be supported, but you'll have to do platform emulation, which makes some things very slow.)  To figure out your system architecture, try runnning ``uname -a``.  The output will look something like::
+You can build all the docker images necessary to create a development/test environment by running the following in the top level directory of your git checkout::
 
-   Linux rosalind 6.12.30+bpo-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.12.30-1~bpo12+1 (2025-06-14) x86_64 GNU/Linux
-
-In this case, the architecture is ``x86_64``; it shows up as the penultimate word on the line.  It won't always show up exactly there, however.  Look for the words ``amd64``, ``x86_64``, ``aarch64``, or ``arm64`` somewhere in that string, probably near the end.  If you see either ``aarch64`` or ``arm64``, then your architecture is ``aarch64``.  If you see either ``amd64`` or ``x86_64``, then your architecture is ``x86_64``.  (Be careful not to confuse ``amd64`` with ``arm64``!) You will use this architecure repreatedly.  If you run::
-
-  export ARCH=<architecture>
-
-replacing ``<architecture>`` with ``x86_64`` or ``aarch64`` as appropriate, then you can leave off the ``ARCH=<architecture>`` at the beginning of all the following ``docker compose commands``, as long as you make sure you run those commands in a shell where you've set this environment variable.
-
-you can build all the docker images necessary to create a development/test environment by running the following in the top level directory of your git checkout::
-
-  ARCH=<architecture> docker compose build
-
-where ``<architecture>`` is either ``x86_64`` or ``aarch64``, as appropriate for your system.
+  docker compose build
 
 Once you've successfully built the docker environments, run::
 
-  ARCH=<architecture> docker compose up -d webap
-  ARCH=<architecture> docker compose up -d shell
+  docker compose up -d webap
+  docker compose up -d shell
 
 (For those of you who know docker compose and are wondering why ``webap`` is not just a prerequisite for ``shell``, the reason is so one can get a debug environment up even when code errors prevent the web application from successfully starting.)
 
@@ -119,7 +107,7 @@ It's possible the shell server won't start, usually because the ``createdb`` ste
 
 to see if there's an obvious error message you know how to fix.  Failing that, you can run::
 
-  ARCH=<architecture> docker compose up -d shell-nocreatedb
+  docker compose up -d shell-nocreatedb
 
 That will bring up a shell server you can connect to and work with that will have the Postgres and Mongo servers running, but which will (probably) not have the tables created on the Postgres server.  (It's also possible other steps will fail, in which more work may potentially be required.)
 
@@ -256,7 +244,7 @@ If you edit the web ap software and what to see the changes, you need to do a co
 
   kill -HUP 1
 
-If all is well, then your webserver is now running the new code; shift-reload it in your browser to see it.  If the webap shell immediately exits after this ``kill`` command, it means you broker the server-side software enough that it no longer runs.  Do ``docker compose logs webap`` to see the logs, and try to fix the errors.  Once you've fixed them, you will need to do ``docker compose down webap`` and ``ARCH=<architecture> docker compose up -d webap`` to get the webap running again.
+If all is well, then your webserver is now running the new code; shift-reload it in your browser to see it.  If the webap shell immediately exits after this ``kill`` command, it means you broker the server-side software enough that it no longer runs.  Do ``docker compose logs webap`` to see the logs, and try to fix the errors.  Once you've fixed them, you will need to do ``docker compose down webap`` and ``docker compose up -d webap`` to get the webap running again.
 
 
 Creating a persistent test user

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -69,7 +69,7 @@ First, you need to figure out your architecture.  If it's not ``x86_64`` or ``aa
 
    Linux rosalind 6.12.30+bpo-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.12.30-1~bpo12+1 (2025-06-14) x86_64 GNU/Linux
 
-In this case, the architecture is ``x86_64``; it shows up as the penultimate word on the line.  You will use this architecure repreatedly.  If you run::
+In this case, the architecture is ``x86_64``; it shows up as the penultimate word on the line.  It won't always show up exactly there, however.  Look for the words ``x86_64``, ``aarch64``, or ``arm64`` somewhere in that string, probably near the end.  If you see either ``aarch64`` or ``arm64``, then your architecture is ``aarch64``.  You will use this architecure repreatedly.  If you run::
 
   export ARCH=<architecture>
 

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -69,7 +69,7 @@ First, you need to figure out your architecture.  If it's not ``x86_64`` or ``aa
 
    Linux rosalind 6.12.30+bpo-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.12.30-1~bpo12+1 (2025-06-14) x86_64 GNU/Linux
 
-In this case, the architecture is ``x86_64``; it shows up as the penultimate word on the line.  It won't always show up exactly there, however.  Look for the words ``x86_64``, ``aarch64``, or ``arm64`` somewhere in that string, probably near the end.  If you see either ``aarch64`` or ``arm64``, then your architecture is ``aarch64``.  You will use this architecure repreatedly.  If you run::
+In this case, the architecture is ``x86_64``; it shows up as the penultimate word on the line.  It won't always show up exactly there, however.  Look for the words ``amd64``, ``x86_64``, ``aarch64``, or ``arm64`` somewhere in that string, probably near the end.  If you see either ``aarch64`` or ``arm64``, then your architecture is ``aarch64``.  If you see either ``amd64`` or ``x86_64``, then your architecture is ``x86_64``.  (Be careful not to confuse ``amd64`` with ``arm64``!) You will use this architecure repreatedly.  If you run::
 
   export ARCH=<architecture>
 

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -31,11 +31,11 @@ to get the current version of all submodules.
 Installing the Code
 ===================
 
-(If you're reading this documentation for the first time, don't try to do what's in this section directly.  Rather, read on.  You will want to refer back to this section later.  First, though, you will probably want to do everything below about setting up a test environment.)
+(If you're reading this documentation for the first time, don't try to do what's in this section directly.  Rather, read on.  You will want to refer back to this section later.  First, though, you will probably want to do everything below about setting up a test environment.  That sections includes everything you need to install the test code.  This section is more general, and what you'd think about if you're trying to install a FASTDB instance somewhere else.)
 
 The code (for the most part) is not designed to be run out of the ``src`` directory where it exists, though you may be able to get that to work.  Ideally, you should install the code first.  Exactly where you're installing it depends on what you're trying to do.  If you're just trying to get a local test environment going on your own machine, see :ref:`local-test-env`.
 
-If you've edited a ``Makefile.am`` file in any directory, or the ``configure.ac`` file in the top-level directory, see :ref:`autoreconv-install` below.  Otherwise, to install the code, you can run just two commands::
+If you've edited a ``Makefile.am`` file in any directory, or the ``configure.ac`` file in the top-level directory, see :ref:`autoreconf-install` below.  Otherwise, to install the code, you can run just two commands::
 
   ./configure --with-installdir=[DIR] --with-smtp-server=[SERVER] --with-smpt-port=[PORT]
   make install
@@ -46,7 +46,7 @@ The first ``[DIR]`` is the directory where you want to install the code.  The SM
 
 as usual with GNU autotools to see what other options are available.  If you're making a production install of FASTDB somewhere, you will definitely want to do things like configure the database connection.
 
-It's possible that after running the first command, you'll get errors about ``aclocal-1.16 is missing on your system`` or something similar.  There are two possibilites; one is that you do legimiately need to rebuild the autotools file, in which case see :ref:`autoreconf-install` below.  If you haven't, it may be result of an unfortunate interaction between autotools and git; autotools (at least some versions) looks at timestamps, but git checkouts do not restore timestamps of files committed to the archive.  In this case, you can run::
+It's possible that after running the first command, you'll get errors about ``aclocal-1.16 is missing on your system`` or something similar.  There are two possibilites; one is that you do legimiately need to rebuild the autotools file, in which case see :ref:`autoreconf-install` below.  However, if you haven't touchedd the files ``aclocal.m4``, ``configure``, or, in any subdirectory, ``Makefile.in`` or ``Makefile.am``, then this error may be result of an unfortunate interaction between autotools and git; autotools (at least some versions) looks at timestamps, but git checkouts do not restore timestamps of files committed to the archive.  In this case, you can run::
 
   touch aclocal.m4 configure
   find . -name Makefile.am -exec touch \{\} \;
@@ -60,33 +60,39 @@ and then retry the ``./configure`` command above.
 Local Test Environment
 =======================
 
-Setup Docker on an ARM Mac (those with Apple Silicon)
------------------------------------------------------
-
-It is recommended to use the Docker Desktop application for ARM Macs. You can download it from https://www.docker.com/products/docker-desktop/ . In the settings deselect Rosetta2:
-
-.. image:: _static/images/docker_settings.png
-   :alt: Docker settings
-
 Build and run the Docker services
 ----------------------------------
 
-The file ``docker-compose.yaml`` in the top-level directory contains (almost) everything necessary to bring up a test FASTDB environment on your local machine.  Make sure you have the docker container runtime and the docker compose extensions installed, make sure that your current working directory is the top-level directory of your git checkout, and run::
+The file ``docker-compose.yaml`` in the top-level directory contains (almost) everything necessary to bring up a test FASTDB environment on your local machine.  You'll need to have some form of docker installed, with a new enough version of ``docker compose``.  Rob is able to get things to work with Docker 20.10.24 (run ``docker --version``) and docker compose 2.36.2 (run ``docker compose version``).  If you have older versions and something doesn't work, try upgrading.  You'll need to have the docker container runtime going; how that works depends on exactly which docker you install.  On a Linux, we rcommend `installing Docker Engline <https://docs.docker.com/engine/install/>`_.  On a Mac, you can also try that, but people have had success with `Docker Desktop <https://www.docker.com/products/docker-desktop>`_.
 
-  docker compose build
+First, you need to figure out your architecture.  If it's not ``x86_64`` or ``aarch64``, then you're system is not supported.  (Or, rather, it may be supported, but you'll have to do platform emulation, which makes some things very slow.)  To figure out your system architecture, try runnning ``uname -a``.  The output will look something like::
 
-Assuming no errors, you should now have built all of the docker images necessary to run the environment.  The first time you run this, it will take a while (several minutes at least).  Subsequent runs will be faster, unless something early in the docker file itself has changed (which does sometimes happen).  If you run it immediately again after you just ran it, it should only take several seconds for it to figure out that everything is up to date.
+   Linux rosalind 6.12.30+bpo-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.12.30-1~bpo12+1 (2025-06-14) x86_64 GNU/Linux
+
+In this case, the architecture is ``x86_64``; it shows up as the penultimate word on the line.  You will use this architecure repreatedly.  If you run::
+
+  export ARCH=<architecture>
+
+replacing ``<architecture>`` with ``x86_64`` or ``aarch64`` as appropriate, then you can leave off the ``ARCH=<architecture>`` at the beginning of all the following ``docker compose commands``, as long as you make sure you run those commands in a shell where you've set this environment variable.
+
+you can build all the docker images necessary to create a development/test environment by running the following in the top level directory of your git checkout::
+
+  ARCH=<architecture> docker compose build
+
+where ``<architecture>`` is either ``x86_64`` or ``aarch64``, as appropriate for your system.
 
 Once you've successfully built the docker environments, run::
 
-  docker compose up -d webap
-  docker compose up -d shell
+  ARCH=<architecture> docker compose up -d webap
+  ARCH=<architecture> docker compose up -d shell
 
 (For those of you who know docker compose and are wondering why ``webap`` is not just a prerequisite for ``shell``, the reason is so one can get a debug environment up even when code errors prevent the web application from successfully starting.)
 
+**NOTE**: sometimes some of the services seem to be failing to come up properly.  It's possible that this is happening because the checks in the docker compose file time out too fast.  You may be able to get it to work by just repeating the ``...docker compose up -d ...`` line; the second time around, it's possible everything will work.  If something doesn't work, look at the service that didn't come up, and try ``docker compose logs <service>`` to see if it sheds any light.
+
 When you run these two commands, it will start a number of local servers (containers) on your machine, and will set up all the basic database tables.  You can run ``docker compose ps`` to see what containers are running.  Assuming you're running these commands on the same machine you're sitting at (i.e. you're running them on your laptop or desktop, not on a remote server you've connected to), and that everything worked, then after this you should be able to connect to the FASTDB web application with your browser by going to:
 
-   ``http://localhost:8080``
+   http://localhost:8080
 
 (You can change the port on your local machine from ``8080`` to something else by setting the ``WEBPORT`` environment variable before running ``docker compose``.)  This will give you the interactive web pages; however, the same URL can be used for API calls documented on :ref:`Using FASTDB <usage-docs>`.  Right after bringing it up, you won't be able to do much with it, because there are no FASTDB users configured.  See :ref:`creating-a-persistent-test-user` below.
 
@@ -113,7 +119,7 @@ It's possible the shell server won't start, usually because the ``createdb`` ste
 
 to see if there's an obvious error message you know how to fix.  Failing that, you can run::
 
-  docker compose up -d shell-nocreatedb
+  ARCH=<architecture> docker compose up -d shell-nocreatedb
 
 That will bring up a shell server you can connect to and work with that will have the Postgres and Mongo servers running, but which will (probably) not have the tables created on the Postgres server.  (It's also possible other steps will fail, in which more work may potentially be required.)
 
@@ -146,8 +152,18 @@ Installing for tests
   ./configure --with-installdir=$PWD/install \
               --with-smtp-server=mailhog \
               --with-smtp-port=1025
-  make install
 
+If you get an error on the ``./configure`` line, it means one of two things.  Either you've edited the file ``aclocal.m4``, or you've edited the file ``Makefile.am`` in one of the subdirectories.  (Never edit any of the ``Makefile.in`` files, as these are all automatically generated.)  If you have edited one of these files, see :ref:`autoreconf-install` below.  If you haven't, then this is the result of autotools and git not agreeing about how file timestamps should be treated.  Try running::
+
+  touch aclocal.m4 configure
+  find . -name Makefile.am -exec touch \{\} \;
+  find . -name Makefile.in -exec touch \{\} \;
+
+and then redoing the ``./configure`` line.
+
+Once your configure has worked, run::
+
+  make install
 
 .. _autoreconf-install:
 
@@ -170,7 +186,7 @@ Unpacking test data
 
 The tests will not yet run as-is.  Inside the ``tests`` subdirectory, you must run::
 
-  bzip2 -d elasticc2_test_data.tar.bz2
+  tar xvf elasticc2_test_data.tar.bz2
 
 in order create the expected test data on your local machine.  Note that ``bzip2`` is *not* installed inside the docker container, so you need to run this on your host machine.  You only need to do this once in your checkout; you do *not* have to do this every time you create a new set of docker containers.  (If the subdirectory ``tests/elasticc2_test_data`` has stuff in it, then you've probably already done this.)
 
@@ -188,8 +204,9 @@ This will completely tear down the environment.  All containers will be stopped,
 Running the tests
 -----------------
 
-Once inside the container, cd into the ``tests`` directory (if you're not there already) and run::
+Once inside the container::
 
+  cd /code/tests
   pytest -v
 
 that will run all of the tests and tell you how they're doing.  As usually with ``pytest``, you can give filenames (and functions or classes/methods within those files) to just run some tests.
@@ -231,15 +248,15 @@ or run::
 
 Both of these start tests with test fixtures that create a database user and load data into the database.  The ``--trace`` command tells pytest to stop at the begining of a test, after the fixture has run.  The shell where you run this will dump you into a ``(Pdb)`` prompt.  Just leave that shell sitting there.  At this point, you have a loaded database.  You can look at ``localhost:8080`` in your web browser to see the web ap, and log in with user ``test`` and password ``test_password``.
 
-The ``test_object_search`` command takes about 10 seconds to run, and loads up the main postgres tables with the test data.  It does *not* load anyting into the mongo database.  The ``test_import_30days_60days`` command takes up to a minute to run, because what it's really doing is testing a whole bunhch of different servers, an there are built in sleeps so that each step of the test can be sure that other servers have had time to do their stuff.  This one loads the full test data set into the "ppdb" tables, and runs a 90 simulated days of alerts through some test brokers.  When it's done, the sources from those 90 simulated days will be in the main postgrest ables, and the mongo database will be populated with  the test broker messages.  (The test brokers aren't doing anything real, but are just assigning random classifications for purposes of testing the plubming.)
+The ``test_object_search`` command takes about 10 seconds to run, and loads up the main postgres tables with the test data.  It does *not* load anyting into the mongo database.  The ``test_import_30days_60days`` command takes up to a minute to run, because what it's really doing is testing a whole bunch of different servers, an there are built in sleeps so that each step of the test can be sure that other servers have had time to do their stuff.  This one loads the full test data set into the "ppdb" tables, and runs a 90 simulated days of alerts through some test brokers.  When it's done, the sources from those 90 simulated days will be in the main postgrest ables, and the mongo database will be populated with  the test broker messages.  (The test brokers aren't doing anything real, but are just assigning random classifications for purposes of testing the plubming.)
 
-When you're done futzing around with the web ap, go to the shee where you ran ``pytest ...`` and just press ``c`` and hit Enter at the ``(Pdb)`` prompt.  The test will compete, exit, and (ideally) clean up after itself.
+When you're done futzing around with the web ap, go to the shell where you ran ``pytest ...`` and just press ``c`` and hit Enter at the ``(Pdb)`` prompt.  The test will compete, exit, and (ideally) clean up after itself.
 
 If you edit the web ap software and what to see the changes, you need to do a couple of things to see the changes.  First, you need to re-install the code.  On a shell inside the container (a different one from the one where your ``(Pdb)`` prompt is sitting), do ``cd /code`` and ``make install``.  (If you've added files, not just edited them, there is more to do; ROB TODO document this.)   Second, you need to get a shell on the webap.  Outside any container, in the ``tests`` directory, run ``docker compose exec -it webap /bin/bash``.  On the shell inside the webap container, run::
 
   kill -HUP 1
 
-If all is well, then your webserver is now running the new code; shift-reload it in your browser to see it.  If the webap shell immediately exits after this ``kill`` command, it means you broker the server-side software enough that it no longer runs.  Do ``docker compose logs webap`` to see the logs, and try to fix the errors.  Once you've fixed them, you will need to do ``docker compose down webap`` and ``docker compose up -d webap`` to get the webap running again.
+If all is well, then your webserver is now running the new code; shift-reload it in your browser to see it.  If the webap shell immediately exits after this ``kill`` command, it means you broker the server-side software enough that it no longer runs.  Do ``docker compose logs webap`` to see the logs, and try to fix the errors.  Once you've fixed them, you will need to do ``docker compose down webap`` and ``ARCH=<architecture> docker compose up -d webap`` to get the webap running again.
 
 
 Creating a persistent test user
@@ -260,6 +277,8 @@ Note for Rob: Installing on Perlmutter
 
 rknop_dev environment
 ---------------------
+
+(This is a note for Rob about running a test environment on NERSC Spin.)
 
 The base installation directory is::
 


### PR DESCRIPTION
I believe I've set now this up so that you can build for just the architecture you need for your system.  I've updated the docs for doing this.

I've also built both `x86_64` and `aarch64` base images and pushed them to dockerhub.
