### PR TITLE
I believe the 30.5, -30.5's 372 radius bug fixed!

### DIFF
--- a/src/webserver/static/objectlist.js
+++ b/src/webserver/static/objectlist.js
@@ -37,8 +37,8 @@ fastdbap.ObjectList = class
                 data.maglast.push( -2.5 * Math.log10( data.lastdetflux[i] ) + 31.4 );
                 data.maglasterr.push( 2.5 / Math.log(10.) * data.lastdetfluxerr[i] / data.lastdetflux[i] );
             } else {
-                data.magmax.push( -99 );
-                data.magmaxerr.push( -99 );
+                data.maglast.push( -99 );
+                data.maglasterr.push( -99 );
             }
             if ( data.lastforcedflux[i] > 0 ) {
                 data.magforcedlast.push( -2.5 * Math.log10( data.lastforcedflux[i] ) + 31.4 );
@@ -135,7 +135,8 @@ fastdbap.ObjectList = class
                                             "classes": [ "borderleft" ] } );
             table.prepend( tr );
         }
-
+        this.fields = fields;
+        this.data = data;
         this.objtable = new rkWebUtil.SortableTable(
             data,
             fields,
@@ -150,6 +151,9 @@ fastdbap.ObjectList = class
 
         // TODO: info about search criteria
         this.topdiv.appendChild( this.objtable.table );
+
+        let bdiv = rkWebUtil.elemaker( 'div', this.topdiv );
+        rkWebUtil.button( bdiv, 'Download CSV', () => { self.download_csv(); } );
     }
 
 
@@ -173,6 +177,26 @@ fastdbap.ObjectList = class
     {
         let info = new fastdbap.ObjectInfo( data, this.context, this.context.objectinfodiv );
         info.render_page();
+    }
+
+    download_csv()
+    {
+        let rows = [];
+        rows.push( this.fields.join(',') );
+        for ( let i in this.data[ this.fields[0] ] ) {
+            let row = [];
+            for ( let f of this.fields ) {
+                row.push( this.data[f][i] );
+            }
+            rows.push( row.join(',') );
+        }
+        let blob = new Blob( [ rows.join('\n') ], { type: 'text/csv;charset=utf-8' } );
+        let url = URL.createObjectURL( blob );
+        let a = rkWebUtil.elemaker( 'a', document.body,
+                                    { 'attributes': { 'href': url, 'download': 'object_list.csv' } } );
+        a.click();
+        document.body.removeChild( a );
+        URL.revokeObjectURL( url );
     }
 
 }


### PR DESCRIPTION
**What’s changed**

- **Array-push fix**  
  Objects with `lastdetflux <= 0` were being pushed into the wrong arrays, causing mismatched lengths and a blank UI.  
  ```diff
  - data.magmax.push(   -99 );
  - data.magmaxerr.push(-99 );
  + data.maglast.push(   -99 );   // push into maglast instead of magmax
  + data.maglasterr.push(-99 );   // push into maglasterr instead of magmaxerr

As a intermediate product of debug (which I decide to keep here) a **`download_csv`** bottom that serializes the current result set into a CSV file to be download from WEB UI:


#### Why I think here is the bug comes from:

Queries against the `elasticc2` database (e.g. RA=30.5, Dec=–30.5, radius 371.7″) produced 29 rows in a Jupyter notebook but a completely blank page in the browser, the one rows added from radius 371.6″ has a negative `lastdetflux`

> *Fun (and slightly painful) debugging aside:* I spent about four hours tracking this down (2½ hours deep in `q3cube.c`’s radial-query math, convinced I’d found an ipix overflow…), only to remember I could try the same query in the NERSC notebook... then the bug was client‑side in the browser JS. (I still suspect the backend’s stability around very large radii (as we saw in the test-sample) —but today’s victory is in two simple JS lines.)