### PR TITLE
Bump test version to make github tests pass

### DIFF
--- a/.github/workflows/run-fastdb-tests.yaml
+++ b/.github/workflows/run-fastdb-tests.yaml
@@ -58,3 +58,6 @@ jobs:
         run: |
           docker compose run --rm runtests
           docker compose down -v
+
+      - name: delete thist block
+        run: docker compose logs postgres

--- a/.github/workflows/run-fastdb-tests.yaml
+++ b/.github/workflows/run-fastdb-tests.yaml
@@ -61,7 +61,8 @@ jobs:
 
       - name: delete this block
         run: |
-          docker compose up -d webap shell
+          docker compose up -d postgres
+          sleep 30
           docker compose logs postgres
           docker compose down -v
         

--- a/.github/workflows/run-fastdb-tests.yaml
+++ b/.github/workflows/run-fastdb-tests.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: astral-sh/ruff-action@v3
         with:
           src: /home/runner/work/FASTDB
-          
+
       - name: pull images
         run: |
           docker compose pull kafka-server postgres mongodb mailhog queryrunner shell webap
@@ -53,16 +53,8 @@ jobs:
         run: |
           cd tests
           tar xf elasticc2_test_data.tar.bz2
-          
-      # - name: run test
-      #   run: |
-      #     docker compose run --rm runtests
-      #     docker compose down -v
 
-      - name: delete this block
+      - name: run test
         run: |
-          docker compose up -d postgres
-          sleep 30
-          docker compose logs postgres
+          docker compose run --rm runtests
           docker compose down -v
-        

--- a/.github/workflows/run-fastdb-tests.yaml
+++ b/.github/workflows/run-fastdb-tests.yaml
@@ -54,10 +54,14 @@ jobs:
           cd tests
           tar xf elasticc2_test_data.tar.bz2
           
-      - name: run test
-        run: |
-          docker compose run --rm runtests
-          docker compose down -v
+      # - name: run test
+      #   run: |
+      #     docker compose run --rm runtests
+      #     docker compose down -v
 
-      - name: delete thist block
-        run: docker compose logs postgres
+      - name: delete this block
+        run: |
+          docker compose up -d webap shell
+          docker compose logs postgres
+          docker compose down -v
+        

--- a/README.md
+++ b/README.md
@@ -1,15 +1,4 @@
 # FASTDB
 Development of the Fast Access to Survey Transients Database (FASTDB).
 
-TODO: get this set up on readthedocs
-
-In the mean time, to read the documentation, check out this git archive.  Make sure you have [Sphinx](https://www.sphinx-doc.org/en/master/index.html) installed on your system.  cd into the `docs` subdirectory of your checkout and run
-```
-make html
-```
-
-Then, point your web browser at:
-```
-file:///path/to/checkout/docs/_build/html/index.html
-```
-replacing `/path/to/checkout` with the absolute path of your git checkout.
+Documentation is on readthedocs : https://fastdb.readthedocs.io

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@
 
 services:
   kafka-zookeeper:
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-kafka-test:${DOCKER_VERSION:-test20250815}
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-kafka-test:${DOCKER_VERSION:-test20250918}
     build:
       context: ./docker/kafka
     healthcheck:
@@ -17,7 +17,7 @@ services:
     depends_on:
        kafka-zookeeper:
          condition: service_healthy
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-kafka-test:${DOCKER_VERSION:-test20250815}
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-kafka-test:${DOCKER_VERSION:-test20250918}
     build:
       context: ./docker/kafka
     healthcheck:
@@ -28,7 +28,7 @@ services:
     entrypoint: [ "bin/kafka-server-start.sh", "config/server.properties" ]
 
   postgres:
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-postgres:${DOCKER_VERSION:-test20250815}
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-postgres:${DOCKER_VERSION:-test20250918}
     build:
       context: ./docker/postgres
       target: postgres
@@ -47,7 +47,7 @@ services:
       retries: 10
 
   mongodb:
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-mongodb:${DOCKER_VERSION:-test20250815}
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-mongodb:${DOCKER_VERSION:-test20250918}
     build:
       context: ./docker/mongodb
     environment:
@@ -74,7 +74,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell:${DOCKER_VERSION:-test20250815}
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell:${DOCKER_VERSION:-test20250918}
     build:
       context: ./docker/webserver
       target: shell
@@ -95,7 +95,7 @@ services:
     depends_on:
       createdb:
         condition: service_completed_successfully
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-query-runner:${DOCKER_VERSION:-test20250815}
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-query-runner:${DOCKER_VERSION:-test20250918}
     build:
       context: ./docker/query_runner
       target: queryrunner
@@ -126,7 +126,7 @@ services:
         condition: service_started
       queryrunner:
         condition: service_started
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-webap:${DOCKER_VERSION:-test20250815}
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-webap:${DOCKER_VERSION:-test20250918}
     build:
       context: ./docker/webserver
       target: webserver
@@ -182,7 +182,7 @@ services:
         condition: service_healthy
       createdb:
         condition: service_completed_successfully
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell:${DOCKER_VERSION:-test20250815}
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell:${DOCKER_VERSION:-test20250918}
     build:
       context: ./docker/webserver
       target: shell
@@ -233,7 +233,7 @@ services:
         condition: service_healthy
       mongodb:
         condition: service_healthy
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell:${DOCKER_VERSION:-test20250815}
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell:${DOCKER_VERSION:-test20250918}
     build:
       context: ./docker/webserver
       target: shell
@@ -279,7 +279,7 @@ services:
     working_dir: /code
 
   makeinstall:
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell:${DOCKER_VERSION:-test20250815}
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell:${DOCKER_VERSION:-test20250918}
     build:
       context: ./docker/webserver
       target: shell
@@ -317,7 +317,7 @@ services:
         condition: service_started   # TODO : health test for webap
       makeinstall:
         condition: service_completed_successfully
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell:${DOCKER_VERSION:-test20250815}
+    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell:${DOCKER_VERSION:-test20250918}
     build:
       context: ./docker/webserver
       target: shell

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@
 
 services:
   kafka-zookeeper:
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-kafka-test:${DOCKER_VERSION:-test20250918}
+    image: ${DOCKER_ARCHIVE:-ghcr.io/lsstdesc}/fastdb-kafka-test:${DOCKER_VERSION:-test20250918}
     build:
       context: ./docker/kafka
     healthcheck:
@@ -17,7 +17,7 @@ services:
     depends_on:
        kafka-zookeeper:
          condition: service_healthy
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-kafka-test:${DOCKER_VERSION:-test20250918}
+    image: ${DOCKER_ARCHIVE:-ghcr.io/lsstdesc}/fastdb-kafka-test:${DOCKER_VERSION:-test20250918}
     build:
       context: ./docker/kafka
     healthcheck:
@@ -28,10 +28,12 @@ services:
     entrypoint: [ "bin/kafka-server-start.sh", "config/server.properties" ]
 
   postgres:
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-postgres:${DOCKER_VERSION:-test20250918}
+    image: ${DOCKER_ARCHIVE:-ghcr.io/lsstdesc}/fastdb-postgres:${DOCKER_VERSION:-test20250918}
     build:
       context: ./docker/postgres
       target: postgres
+      args:
+        NERSCSPIN: ${NERSCSPIN:-0}
     volumes:
       - type: volume
         source: postgres_data
@@ -47,7 +49,7 @@ services:
       retries: 10
 
   mongodb:
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-mongodb:${DOCKER_VERSION:-test20250918}
+    image: ${DOCKER_ARCHIVE:-ghcr.io/lsstdesc}/fastdb-mongodb:${DOCKER_VERSION:-test20250918}
     build:
       context: ./docker/mongodb
     environment:
@@ -74,7 +76,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell:${DOCKER_VERSION:-test20250918}
+    image: ${DOCKER_ARCHIVE:-ghcr.io/lsstdesc}/fastdb-shell:${DOCKER_VERSION:-test20250918}
     build:
       context: ./docker/webserver
       target: shell
@@ -95,7 +97,7 @@ services:
     depends_on:
       createdb:
         condition: service_completed_successfully
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-query-runner:${DOCKER_VERSION:-test20250918}
+    image: ${DOCKER_ARCHIVE:-ghcr.io/lsstdesc}/fastdb-query-runner:${DOCKER_VERSION:-test20250918}
     build:
       context: ./docker/query_runner
       target: queryrunner
@@ -126,7 +128,7 @@ services:
         condition: service_started
       queryrunner:
         condition: service_started
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-webap:${DOCKER_VERSION:-test20250918}
+    image: ${DOCKER_ARCHIVE:-ghcr.io/lsstdesc}/fastdb-webap:${DOCKER_VERSION:-test20250918}
     build:
       context: ./docker/webserver
       target: webserver
@@ -182,7 +184,7 @@ services:
         condition: service_healthy
       createdb:
         condition: service_completed_successfully
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell:${DOCKER_VERSION:-test20250918}
+    image: ${DOCKER_ARCHIVE:-ghcr.io/lsstdesc}/fastdb-shell:${DOCKER_VERSION:-test20250918}
     build:
       context: ./docker/webserver
       target: shell
@@ -233,7 +235,7 @@ services:
         condition: service_healthy
       mongodb:
         condition: service_healthy
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell:${DOCKER_VERSION:-test20250918}
+    image: ${DOCKER_ARCHIVE:-ghcr.io/lsstdesc}/fastdb-shell:${DOCKER_VERSION:-test20250918}
     build:
       context: ./docker/webserver
       target: shell
@@ -279,7 +281,7 @@ services:
     working_dir: /code
 
   makeinstall:
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell:${DOCKER_VERSION:-test20250918}
+    image: ${DOCKER_ARCHIVE:-ghcr.io/lsstdesc}/fastdb-shell:${DOCKER_VERSION:-test20250918}
     build:
       context: ./docker/webserver
       target: shell
@@ -317,7 +319,7 @@ services:
         condition: service_started   # TODO : health test for webap
       makeinstall:
         condition: service_completed_successfully
-    image: ${DOCKER_ARCHIVE:-registry.nersc.gov/m1727/raknop}/fastdb-shell:${DOCKER_VERSION:-test20250918}
+    image: ${DOCKER_ARCHIVE:-ghcr.io/lsstdesc}/fastdb-shell:${DOCKER_VERSION:-test20250918}
     build:
       context: ./docker/webserver
       target: shell

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -30,11 +30,6 @@ ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 
-
-RUN echo "host all all 0.0.0.0/0 md5" >> /etc/postgresql/15/main/pg_hba.conf
-COPY postgresql.conf /etc/postgresql/15/main/postgresql.conf
-ENV POSTGRES_DATA_DIR=/var/lib/postgresql/data
-
 ENV LESS=-XLRi
 
 # ======================================================================
@@ -82,9 +77,8 @@ RUN cd /opt/rust \
   && cd pg_parquet-${PG_PARQUET_VERSION} \
   && cargo pgrx install --release
 
-
 # ======================================================================
-FROM base AS postgres
+FROM base AS conf
 
 COPY --from=build /usr/lib/postgresql/15/lib/q3c.so /usr/lib/postgresql/15/lib/q3c.so
 COPY --from=build /usr/lib/postgresql/15/lib/bitcode/q3c /usr/share/postgresql/lib/bitcode/q3c
@@ -96,6 +90,26 @@ COPY --from=build /usr/lib/postgresql/15/lib/bitcode/pg_hint_plan.index.bc /usr/
 COPY --from=build /usr/share/postgresql/15/extension/pg_hint_plan* /usr/share/postgresql/15/extension/
 COPY --from=build /usr/lib/postgresql/15/lib/pg_parquet.so /usr/lib/postgresql/15/lib/
 COPY --from=build /usr/share/postgresql/15/extension/pg_parquet* /usr/share/postgresql/15/extension/
+
+RUN echo "host all all 0.0.0.0/0 md5" >> /etc/postgresql/15/main/pg_hba.conf
+
+# Have to configure postgres for different amounts of memory for NERSC Spin
+# and github CI
+ARG NERSCSPIN=0
+COPY postgresql.conf /etc/postgresql/15/main/postgresql.conf
+RUN cd /etc/postgresql/15/main \
+ && if [ "$NERSCSPIN" = "1" ] ; then \
+      cat postgresql.conf | sed 's/${config_shared_buffers}/32GB/; s/${config_temp_buffers}/4GB/; s/${config_work_mem}/4GB/; s/${config_maintenance_work_mem}/4GB/;' > postgresql.conf.new; \
+    else \
+      cat postgresql.conf | sed 's/${config_shared_buffers}/2GB/; s/${config_temp_buffers}/1GB/; s/${config_work_mem}/1GB/; s/${config_maintenance_work_mem}/1GB/;' > postgresql.conf.new ; \
+    fi \
+ && mv postgresql.conf.new postgresql.conf
+ 
+
+ENV POSTGRES_DATA_DIR=/var/lib/postgresql/data
+
+# ======================================================================
+FROM conf AS postgres
 
 # Make sure the contents of run_postgres.sh what is in postgresql.conf.
 # (There is some futzing about here to make sure the right permissions are
@@ -114,7 +128,7 @@ CMD ["bash", "/run_postgres.sh"]
 
 # ======================================================================
 
-FROM base AS pgdump
+FROM conf AS pgdump
 
 RUN mkdir=/home/pgdump
 ENV HOME=/home/pgdump

--- a/docker/postgres/postgresql.conf
+++ b/docker/postgres/postgresql.conf
@@ -126,11 +126,13 @@ ssl_key_file = '/etc/ssl/private/ssl-cert-snakeoil.key'
 
 # RKNOP 2022-08-19 : commented shared_buffers=128MB, added others here
 # RKNOP 2025-09-16 : bumped some numbers
+# RKNOP 2025-09-18 : the numbers were too big for github CI,
+#                        so we had to make them parameters
 
-shared_buffers = 32GB
-temp_buffers = 4GB
-work_mem = 4GB
-maintenance_work_mem = 4GB
+shared_buffers = ${config_shared_buffers}
+temp_buffers = ${config_temp_buffers}
+work_mem = ${config_work_mem}
+maintenance_work_mem = ${config_maintenance_work_mem}
 
 # shared_buffers = 128MB			# min 128kB
 					# (change requires restart)

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -326,12 +326,14 @@ Notes and Tips for Development and Testing
 Running tests on github CI
 --------------------------
 
-The tests on github CI require up-to-date docker images.  They don't change very often, so usually you don't have to do anything.  However, if they have changed, then you need to do edit ``docker-compose.yaml`` and bump the default version of all the images.  You'll see that all the images end in ``${DOCKER_VERSION:-test20250815}`` (or some other yyyymmdd).  Bump the date to the current date on all the images.  Then do the following, in all places replacing 20250815 with your new ``yyyymmdd``::
+The tests on github CI require up-to-date docker images.  They don't change very often, so usually you don't have to do anything.  However, if they have changed, then you need to do edit ``docker-compose.yaml`` and bump the default version of all the images.  You'll see that all the images end in ``${DOCKER_VERSION:-test20250815}`` (or some other yyyymmdd).  Bump the date to the current date on all the images.  Then do::
 
+  yyyymmdd=20250815    # replace this with the yyyymmdd you put in docker-compose.yaml
   DOCKER_ARCHIVE=ghcr.io/lsstdesc docker compose build
-  docker images | grep ghcr.*test20250815
-  for i in fastdb-postgres fastdb-webap fastdb-shell fastdb-kafka-test fastdb-query-runner fastdb-mongodb ; \
-     do docker push ghcr.io/lsstdesc/${i}:test20250815 ; \
+  docker images | grep ghcr.*test${yyyymmdd}
+  for i in fastdb-postgres fastdb-webap fastdb-shell fastdb-kafka-test \
+           fastdb-query-runner fastdb-mongodb ; \
+     do docker push ghcr.io/lsstdesc/${i}:test${yyyymmdd} ; \
      done
 
 After you've done this, do a ``git push``, or create a pull request, or do whatever it is you normally do that triggers the running of the automated tests on github.

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -329,8 +329,8 @@ Running tests on github CI
 The tests on github CI require up-to-date docker images.  They don't change very often, so usually you don't have to do anything.  However, if they have changed, then you need to do edit ``docker-compose.yaml`` and bump the default version of all the images.  You'll see that all the images end in ``${DOCKER_VERSION:-test20250815}`` (or some other yyyymmdd).  Bump the date to the current date on all the images.  Then do::
 
   yyyymmdd=20250815    # replace this with the yyyymmdd you put in docker-compose.yaml
-  DOCKER_ARCHIVE=ghcr.io/lsstdesc docker compose build
-  docker images | grep ghcr.*test${yyyymmdd}
+  docker compose build
+  docker images | grep ghcr.*fastdb.*test${yyyymmdd}
   for i in fastdb-postgres fastdb-webap fastdb-shell fastdb-kafka-test \
            fastdb-query-runner fastdb-mongodb ; \
      do docker push ghcr.io/lsstdesc/${i}:test${yyyymmdd} ; \
@@ -409,6 +409,15 @@ When creating the migration, be aware that this needs to be applied to productio
 
 Note for Rob: Installing on Perlmutter
 ======================================
+
+building
+--------
+
+Do::
+
+  NERSCSPIN=1 DOCKER_ARCHIVE=registry.nersc.gov/m1727/raknop DOCKER_VERSION=<version> docker compose build
+
+where ``<version>`` is probably something like ``rknop-dev``.
 
 rknop_dev environment
 ---------------------

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -323,6 +323,20 @@ TODO
 Notes and Tips for Development and Testing
 ==========================================
 
+Running tests on github CI
+--------------------------
+
+The tests on github CI require up-to-date docker images.  They don't change very often, so usually you don't have to do anything.  However, if they have changed, then you need to do edit ``docker-compose.yaml`` and bump the default version of all the images.  You'll see that all the images end in ``${DOCKER_VERSION:-test20250815}`` (or some other yyyymmdd).  Bump the date to the current date on all the images.  Then do the following, in all places replacing 20250815 with your new ``yyyymmdd``::
+
+  DOCKER_ARCHIVE=ghcr.io/lsstdesc docker compose build
+  docker images | grep ghcr.*test20250815
+  for i in fastdb-postgres fastdb-webap fastdb-shell fastdb-kafka-test fastdb-query-runner fastdb-mongodb ; \
+     do docker push ghcr.io/lsstdesc/${i}:test20250815 ; \
+     done
+
+After you've done this, do a ``git push``, or create a pull request, or do whatever it is you normally do that triggers the running of the automated tests on github.
+
+
 Changing database structures
 ----------------------------
 


### PR DESCRIPTION
Also makes the postgres memory configuration itself configurable, so we can have docker images on spin that have bigger memory buffers than what github CI allows.